### PR TITLE
Fixed get* functions not returning any values

### DIFF
--- a/src/playtube.js
+++ b/src/playtube.js
@@ -116,7 +116,7 @@ Playtube.promisifyPlayer = function (playerAPIReady) {
 
             return playerAPIReady
                 .then(function (player) {
-                    player[methodName].apply(player, callArguments);
+                    return player[methodName].apply(player, callArguments);
                 });
         };
     });


### PR DESCRIPTION
None of the get* functions exposed by playtube resolved in any values, which meant that although you could call them, you'd never be able to get the results.

The commit in this PR resolves this issue by making all promises always resolve into the YTAPI call return values.